### PR TITLE
Adding visualization in STFT domain

### DIFF
--- a/demo_cdr_dereverb.m
+++ b/demo_cdr_dereverb.m
@@ -112,3 +112,15 @@ colorbar
 title('Filter gain')
 xlabel('frame index')
 ylabel('subband index')
+
+%% Dereverberation visualization
+
+figure; 
+subplot(211); imagesc(10*log10(abs(Postfilter_input))); 
+colormap('jet'); ylabel('subband index');
+set(gca,'YDir','normal'); title('|Y(l,f)|'); colorbar;
+
+subplot(212); imagesc(10*log10(abs(Processed))); 
+ylabel('subband index');xlabel('frame index'); 
+set(gca,'YDir','normal');
+title('|Z(l,f)|'); colorbar;colormap('jet');


### PR DESCRIPTION
Adding visualization for the processed signal and the output of the CDR-based postfilter in STFT domain. It shows visually the dereverberation.